### PR TITLE
R4R: Add appHash checking in replay mode and fix bug about replay boundary

### DIFF
--- a/consensus/replay.go
+++ b/consensus/replay.go
@@ -6,6 +6,7 @@ import (
 	"hash/crc32"
 	"io"
 	"reflect"
+	"runtime"
 	//"strconv"
 	//"strings"
 	"time"
@@ -427,7 +428,8 @@ func (h *Handshaker) replayBlocks(state sm.State, proxyApp proxy.AppConns, appBl
 		}
 
 		if config.ReplayHeight > 0 && i >= config.ReplayHeight {
-			cmn.Exit(fmt.Sprintf("Replay from height %d to height %d successfully", appBlockHeight, config.ReplayHeight))
+			fmt.Printf("Replay from height %d to height %d successfully", appBlockHeight, config.ReplayHeight)
+			runtime.Goexit()
 		}
 
 		h.nBlocks++

--- a/consensus/replay.go
+++ b/consensus/replay.go
@@ -418,7 +418,7 @@ func (h *Handshaker) replayBlocks(state sm.State, proxyApp proxy.AppConns, appBl
 
 		if len(appHash) != 0 {
 			if !bytes.Equal(block.Header.AppHash, appHash) {
-				panic(fmt.Sprintf("Mismatch replay appHash, expected %s, actual %s", block.AppHash.String(), cmn.HexBytes(appHash).String()))
+				panic(fmt.Sprintf("AppHash mismatch: expected %s, actual %s", block.AppHash.String(), cmn.HexBytes(appHash).String()))
 			}
 		}
 

--- a/consensus/replay.go
+++ b/consensus/replay.go
@@ -414,12 +414,19 @@ func (h *Handshaker) replayBlocks(state sm.State, proxyApp proxy.AppConns, appBl
 	for i := appBlockHeight + 1; i <= finalBlock; i++ {
 		h.logger.Info("Applying block", "height", i)
 		block := h.store.LoadBlock(i)
+
+		if len(appHash) != 0 {
+			if !bytes.Equal(block.Header.AppHash, appHash) {
+				panic(fmt.Sprintf("Mismatch replay appHash, expected %s, actual %s", block.AppHash.String(), cmn.HexBytes(appHash).String()))
+			}
+		}
+
 		appHash, err = sm.ExecCommitBlock(proxyApp.Consensus(), block, h.logger, state.LastValidators, h.stateDB)
 		if err != nil {
 			return nil, err
 		}
 
-		if config.ReplayHeight > 0 && i > config.ReplayHeight {
+		if config.ReplayHeight > 0 && i >= config.ReplayHeight {
 			cmn.Exit(fmt.Sprintf("Replay from height %d to height %d successfully", appBlockHeight, config.ReplayHeight))
 		}
 


### PR DESCRIPTION
The inconsistence about rebuilding app state and actual app state is caused by wrong replay bondary. After replaying blocks, the lastest app state will be loaded. 

So previously, we just exported the app state at next height. For instance, current state heigth is 12000, and we want to export at height 11000, then what we should do is loading app state at height 10000, and replaying to height 11000, and export app state at heitht 11000. However, the actual operation we do is loading app state at height 10000, and replaying to height 11001, and export app state at heitht 11001.

This PR fixed this bug and appHash checking during replaying process.