### PR TITLE
R4R: Fix internal error in /tx_search when results are empty

### DIFF
--- a/rpc/client/rpc_test.go
+++ b/rpc/client/rpc_test.go
@@ -428,5 +428,10 @@ func TestTxSearch(t *testing.T) {
 		if len(result.Txs) == 0 {
 			t.Fatal("expected a lot of transactions")
 		}
+
+		// query a non existing tx with page 1 and txsPerPage 1
+		result, err = c.TxSearch("app.creator='Cosmoshi Neetowoko'", true, 1, 1)
+		require.Nil(t, err, "%+v", err)
+		require.Len(t, result.Txs, 0)
 	}
 }

--- a/rpc/core/pipe.go
+++ b/rpc/core/pipe.go
@@ -154,3 +154,12 @@ func validatePerPage(perPage int) int {
 	}
 	return perPage
 }
+
+func validateSkipCount(page, perPage int) int {
+	skipCount := (page - 1) * perPage
+	if skipCount < 0 {
+		return 0
+	}
+
+	return skipCount
+}

--- a/rpc/core/tx.go
+++ b/rpc/core/tx.go
@@ -202,7 +202,7 @@ func TxSearch(query string, prove bool, page, perPage int) (*ctypes.ResultTxSear
 	totalCount := len(hashes)
 	perPage = validatePerPage(perPage)
 	page = validatePage(page, perPage, totalCount)
-	skipCount := (page - 1) * perPage
+	skipCount := validateSkipCount(page, perPage)
 
 	apiResults := make([]*ctypes.ResultTx, cmn.MinInt(perPage, totalCount-skipCount))
 	var proof types.TxProof


### PR DESCRIPTION
Resolves: https://github.com/irisnet/irishub/issues/1428
