### PR TITLE
R4R: Improve tx search

### DIFF
--- a/rpc/core/pipe.go
+++ b/rpc/core/pipe.go
@@ -1,6 +1,8 @@
 package core
 
 import (
+	"fmt"
+
 	"github.com/tendermint/tendermint/consensus"
 	"github.com/tendermint/tendermint/crypto"
 	"github.com/tendermint/tendermint/libs/log"
@@ -133,19 +135,24 @@ func SetEventBus(b *types.EventBus) {
 	eventBus = b
 }
 
-func validatePage(page, perPage, totalCount int) int {
+func validatePage(page, perPage, totalCount int) (int, error) {
 	if perPage < 1 {
-		return 1
+		panic(fmt.Sprintf("zero or negative perPage: %d", perPage))
+	}
+
+	if page == 0 {
+		return 1, nil // default
 	}
 
 	pages := ((totalCount - 1) / perPage) + 1
-	if page < 1 {
-		page = 1
-	} else if page > pages {
-		page = pages
+	if pages == 0 {
+		pages = 1 // one page (even if it's empty)
+	}
+	if page < 0 || page > pages {
+		return 1, fmt.Errorf("page should be within [0, %d] range, given %d", pages, page)
 	}
 
-	return page
+	return page, nil
 }
 
 func validatePerPage(perPage int) int {

--- a/rpc/core/pipe_test.go
+++ b/rpc/core/pipe_test.go
@@ -14,40 +14,45 @@ func TestPaginationPage(t *testing.T) {
 		perPage    int
 		page       int
 		newPage    int
+		expErr     bool
 	}{
-		{0, 0, 1, 1},
+		{0, 10, 1, 1, false},
 
-		{0, 10, 0, 1},
-		{0, 10, 1, 1},
-		{0, 10, 2, 1},
+		{0, 10, 0, 1, false},
+		{0, 10, 1, 1, false},
+		{0, 10, 2, 0, true},
 
-		{5, 10, -1, 1},
-		{5, 10, 0, 1},
-		{5, 10, 1, 1},
-		{5, 10, 2, 1},
-		{5, 10, 2, 1},
+		{5, 10, -1, 0, true},
+		{5, 10, 0, 1, false},
+		{5, 10, 1, 1, false},
+		{5, 10, 2, 0, true},
+		{5, 10, 2, 0, true},
 
-		{5, 5, 1, 1},
-		{5, 5, 2, 1},
-		{5, 5, 3, 1},
+		{5, 5, 1, 1, false},
+		{5, 5, 2, 0, true},
+		{5, 5, 3, 0, true},
 
-		{5, 3, 2, 2},
-		{5, 3, 3, 2},
+		{5, 3, 2, 2, false},
+		{5, 3, 3, 0, true},
 
-		{5, 2, 2, 2},
-		{5, 2, 3, 3},
-		{5, 2, 4, 3},
+		{5, 2, 2, 2, false},
+		{5, 2, 3, 3, false},
+		{5, 2, 4, 0, true},
 	}
 
 	for _, c := range cases {
-		p := validatePage(c.page, c.perPage, c.totalCount)
+		p, err := validatePage(c.page, c.perPage, c.totalCount)
+		if c.expErr {
+			assert.Error(t, err)
+			continue
+		}
+
 		assert.Equal(t, c.newPage, p, fmt.Sprintf("%v", c))
 	}
 
 }
 
 func TestPaginationPerPage(t *testing.T) {
-
 	cases := []struct {
 		totalCount int
 		perPage    int

--- a/rpc/core/tx.go
+++ b/rpc/core/tx.go
@@ -200,7 +200,10 @@ func TxSearch(query string, prove bool, page, perPage int) (*ctypes.ResultTxSear
 
 	totalCount := len(hashes)
 	perPage = validatePerPage(perPage)
-	page = validatePage(page, perPage, totalCount)
+	page, err = validatePage(page, perPage, totalCount)
+	if err != nil {
+		return nil, err
+	}
 	skipCount := validateSkipCount(page, perPage)
 
 	apiResults := make([]*ctypes.ResultTx, cmn.MinInt(perPage, totalCount-skipCount))

--- a/rpc/core/tx.go
+++ b/rpc/core/tx.go
@@ -3,13 +3,12 @@ package core
 import (
 	"fmt"
 
+	"github.com/pkg/errors"
 	cmn "github.com/tendermint/tendermint/libs/common"
-
 	tmquery "github.com/tendermint/tendermint/libs/pubsub/query"
 	ctypes "github.com/tendermint/tendermint/rpc/core/types"
 	"github.com/tendermint/tendermint/state/txindex/null"
 	"github.com/tendermint/tendermint/types"
-	"github.com/pkg/errors"
 )
 
 // Tx allows you to query the transaction results. `nil` could mean the
@@ -208,7 +207,7 @@ func TxSearch(query string, prove bool, page, perPage int) (*ctypes.ResultTxSear
 	var proof types.TxProof
 	for i := 0; i < len(apiResults); i++ {
 		h := hashes[skipCount+i]
-		r, err := txIndexer.Get(h)
+		r, err := txIndexer.Get(h.Hash)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to get Tx{%X}", h)
 		}

--- a/state/txindex/indexer.go
+++ b/state/txindex/indexer.go
@@ -20,7 +20,12 @@ type TxIndexer interface {
 	Get(hash []byte) (*types.TxResult, error)
 
 	// Search allows you to query for transactions.
-	Search(q *query.Query) ([][]byte, error)
+	Search(q *query.Query) ([]TxHash, error)
+}
+
+type TxHash struct {
+	Index string
+	Hash  []byte
 }
 
 //----------------------------------------------------

--- a/state/txindex/kv/kv.go
+++ b/state/txindex/kv/kv.go
@@ -2,6 +2,7 @@ package kv
 
 import (
 	"bytes"
+	"encoding/binary"
 	"encoding/hex"
 	"fmt"
 	"sort"
@@ -514,10 +515,14 @@ func keyForHeight(result *types.TxResult) []byte {
 func ConvertKey2Index(key []byte) string {
 	ss := strings.Split(string(key), tagKeySeparator)
 	if len(ss) == 4 {
-		height, _ := strconv.ParseUint(ss[2], 10, 64)
+		height, _ := strconv.ParseInt(ss[2], 10, 64)
 		index, _ := strconv.ParseUint(ss[3], 10, 32)
+		indexBytes := make([]byte, 8+4)
 
-		return fmt.Sprintf("%08d%s%04d", height, tagKeySeparator, index)
+		binary.BigEndian.PutUint64(indexBytes[0:8], uint64(height))
+		binary.BigEndian.PutUint32(indexBytes[8:12], uint32(index))
+
+		return string(indexBytes)
 	}
 	return string(key)
 }

--- a/state/txindex/kv/kv_bench_test.go
+++ b/state/txindex/kv/kv_bench_test.go
@@ -1,0 +1,67 @@
+package kv
+
+import (
+	"crypto/rand"
+	"fmt"
+	"io/ioutil"
+	"testing"
+
+	abci "github.com/tendermint/tendermint/abci/types"
+	cmn "github.com/tendermint/tendermint/libs/common"
+	"github.com/tendermint/tendermint/libs/pubsub/query"
+	"github.com/tendermint/tendermint/types"
+	dbm "github.com/tendermint/tm-db"
+)
+
+func BenchmarkTxSearch(b *testing.B) {
+	dbDir, err := ioutil.TempDir("", "benchmark_tx_search_test")
+	if err != nil {
+		b.Errorf("failed to create temporary directory: %s", err)
+	}
+
+	db, err := dbm.NewGoLevelDB("benchmark_tx_search_test", dbDir)
+	if err != nil {
+		b.Errorf("failed to create database: %s", err)
+	}
+
+	allowedTags := []string{"address", "amount"}
+	indexer := NewTxIndex(db, IndexTags(allowedTags))
+
+	for i := 0; i < 100000; i++ {
+		tags := []cmn.KVPair{
+			{Key: []byte("address"), Value: []byte(fmt.Sprintf("address_%d", i%10))},
+			{Key: []byte("amount"), Value: []byte("50")},
+		}
+
+		txBz := make([]byte, 8)
+		if _, err := rand.Read(txBz); err != nil {
+			b.Errorf("failed produce random bytes: %s", err)
+		}
+
+		txResult := &types.TxResult{
+			Height: int64(i),
+			Index:  0,
+			Tx:     types.Tx(string(txBz)),
+			Result: abci.ResponseDeliverTx{
+				Data: []byte{0},
+				Code: abci.CodeTypeOK,
+				Log:  "",
+				Tags: tags,
+			},
+		}
+
+		if err := indexer.Index(txResult); err != nil {
+			b.Errorf("failed to index tx: %s", err)
+		}
+	}
+
+	txQuery := query.MustParse("address = 'address_4' AND amount = '50'")
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		if _, err := indexer.Search(txQuery); err != nil {
+			b.Errorf("failed to query for txs: %s", err)
+		}
+	}
+}

--- a/state/txindex/null/null.go
+++ b/state/txindex/null/null.go
@@ -28,6 +28,6 @@ func (txi *TxIndex) Index(result *types.TxResult) error {
 	return nil
 }
 
-func (txi *TxIndex) Search(q *query.Query) ([][]byte, error) {
-	return [][]byte{}, nil
+func (txi *TxIndex) Search(q *query.Query) ([]txindex.TxHash, error) {
+	return []txindex.TxHash{}, nil
 }


### PR DESCRIPTION
Resolves: https://github.com/irisnet/irishub/issues/1922

We store tag(index) with key == `tag.Key/tag.Value/tx.Height/tx.Index`, and we search txs by following these steps:

1. find all txs' hash by tag.Key and tag.Value, such as `action=send`
2. find all txs by tx's hash
3. sort all txs by tx.height and tx.index
4. get results by pagination

-----------------------------------------
Actually, the tag's key also contains tx.height and tx.index, so we can adjust the above steps to 1、3、4、2. This can greatly reduce the count of tx query by tx.hash.
